### PR TITLE
Implement `vmcli start --verbose`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -66,6 +66,7 @@ dependencies:
   - process
   - safe-exceptions
   - string-conversions
+  - strip-ansi-escape
   - text
   - unix
   - xdg-basedir

--- a/spec/IntegrationSpec.hs
+++ b/spec/IntegrationSpec.hs
@@ -13,6 +13,7 @@ import Data.String.Interpolate (i)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
 import NixVms qualified
+import Options (VmName (..))
 import State (readState)
 import StdLib
 import System.Directory (doesDirectoryExist, listDirectory)

--- a/spec/TestUtils.hs
+++ b/spec/TestUtils.hs
@@ -10,6 +10,7 @@ import Data.String (IsString)
 import Data.String.Conversions
 import GHC.Exts (IsString (..))
 import Network.Socket.Free (getFreePort)
+import Options (VmName (..))
 import Run (run)
 import State
 import StdLib
@@ -80,7 +81,7 @@ withMockContext vmNames action = do
         NixVms
           { listVms = \_ctx -> pure vmNames,
             buildAndRun =
-              \ctx vmName -> do
+              \ctx _verbosity vmName -> do
                 unless (vmName `elem` vmNames) $ do
                   error $ cs $ "nix vm mock: vm not found: " <> vmNameToText vmName
                 (_, _, _, ph) <- do

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -15,7 +15,7 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Options (StartOptions (..))
+import Options (StartOptions (..), Verbosity, VmName (..))
 import State
 import StdLib
 import System.Directory (doesFileExist)
@@ -32,8 +32,8 @@ list ctx = do
     [] -> "no vms configured"
     vms -> "configured vms: " <> T.intercalate ", " (map vmNameToText vms)
 
-start :: Context -> StartOptions -> IO ()
-start ctx startOptions = do
+start :: Context -> Verbosity -> StartOptions -> IO ()
+start ctx verbosity startOptions = do
   vmNames <- case startOptions of
     StartAll -> do
       vmNames <- listVms (nixVms ctx) ctx
@@ -57,7 +57,7 @@ start ctx startOptions = do
             -- todo: make runtime dep
             Cradle.cmd "ssh-keygen"
               & Cradle.addArgs ["-f", vmKeyPath, "-N", ""]
-        ph <- buildAndRun (nixVms ctx) ctx vmName
+        ph <- buildAndRun (nixVms ctx) ctx verbosity vmName
         registerProcess ctx ph
         pid <- getPid ph <&> fromMaybe (error "no pid")
         state <- readState ctx vmName

--- a/src/Context.hs
+++ b/src/Context.hs
@@ -1,6 +1,7 @@
 module Context where
 
 import Cradle qualified
+import Options (Verbosity, VmName)
 import StdLib
 import System.IO
 import System.Process
@@ -16,9 +17,6 @@ data Context = Context
 
 data NixVms = NixVms
   { listVms :: Context -> IO [VmName],
-    buildAndRun :: Context -> VmName -> IO ProcessHandle,
+    buildAndRun :: Context -> Verbosity -> VmName -> IO ProcessHandle,
     sshIntoHost :: forall o. (Cradle.Output o) => Context -> VmName -> [Text] -> IO o
   }
-
-newtype VmName = VmName {vmNameToText :: Text}
-  deriving stock (Eq, Show, Ord)

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -26,7 +26,7 @@ run ctx args =
     (Options opts) <- handleParseResult $ execParserPure (prefs showHelpOnError) parser (cs <$> args)
     case opts of
       List -> list ctx
-      Start vmNames -> start ctx vmNames
+      Start verbosity vmNames -> start ctx verbosity vmNames
       Stop vmName -> stop ctx vmName
       Ssh vmName command -> ssh ctx vmName command
       Status vmNames -> status ctx vmNames

--- a/src/State.hs
+++ b/src/State.hs
@@ -5,6 +5,7 @@ import Control.Monad (filterM)
 import Data.Aeson
 import Data.String.Conversions (cs)
 import Data.Text.IO qualified as T
+import Options (VmName (..))
 import StdLib
 import System.Directory
   ( createDirectoryIfMissing,

--- a/vmcli.cabal
+++ b/vmcli.cabal
@@ -55,6 +55,7 @@ executable vmcli
     , process
     , safe-exceptions
     , string-conversions
+    , strip-ansi-escape
     , text
     , unix
     , xdg-basedir
@@ -120,6 +121,7 @@ test-suite spec
     , safe-exceptions
     , silently
     , string-conversions
+    , strip-ansi-escape
     , temporary
     , text
     , unix


### PR DESCRIPTION
I didn't add any tests for this, since there's a lot of behavior that I had to manually test to make sure it works. It'd be a lot of work to have tests for all these corner cases. Although we could add some with the mocks. WDYT?

Ah, it's not that easily mockable, since the `NixVms` mock doesn't use the same code path as `runVm`.