### PR TITLE
Add test for Ctrl+C behavior

### DIFF
--- a/spec/IntegrationSpec.hs
+++ b/spec/IntegrationSpec.hs
@@ -99,6 +99,13 @@ spec = do
       cs (stderr result) `shouldContain` "Building NixOS config...\nCommand exited with code 1"
       cs (stderr result) `shouldContain` "does not provide attribute 'packages.x86_64-linux.nixosConfigurations.\"does-not-exist\""
 
+    it "`vmcli start` doesn't mess up the terminal" $ \ctx -> do
+      writeStandardFlake ctx Nothing
+      Cradle.StdoutRaw before <- Cradle.run $ Cradle.cmd "stty" & Cradle.addArgs ["-a" :: Text]
+      _ <- assertSuccess $ test ctx ["start", "server"]
+      Cradle.StdoutRaw after <- Cradle.run $ Cradle.cmd "stty" & Cradle.addArgs ["-a" :: Text]
+      after `shouldBe` before
+
     it "starts vms with arbitrary hostnames" $ \ctx -> do
       writeStandardFlake ctx (Just "{ lib, ...} : { networking.hostName = lib.mkForce \"other-hostname\"; }")
       _ <- assertSuccess $ test ctx ["up", "server"]


### PR DESCRIPTION
Backfilling some tests for the Ctrl-C behavior. Could be merged once ttys are available in garnix actions.