### PR TITLE
Prevent `vmcli start` from messing up Ctrl+C

### DIFF
--- a/src/NixVms.hs
+++ b/src/NixVms.hs
@@ -143,6 +143,7 @@ runVm ctx verbosity vmName vmExecutable = do
   let mkProc stdout stdin =
         (System.Process.proc vmExecutable [])
           { env = Just $ Map.toList $ Map.insert "NIX_DISK_IMAGE" nixDiskImage parentEnvironment,
+            std_in = CreatePipe,
             std_out = stdout,
             std_err = stdin
           }


### PR DESCRIPTION
The tty tests don't work on CI. So here's the fix without the tests. Here's also a separate PR for just the tests: https://github.com/garnix-io/vmcli/pull/8