### PR TITLE
Rename vde ctl dir

### DIFF
--- a/.golden/storage-tree/golden
+++ b/.golden/storage-tree/golden
@@ -1,6 +1,6 @@
 .
 ├── state.json
-├── vde1.ctl
+├── vde_switch.ctl
 │   ├── 001.9
 │   └── ctl
 └── vms

--- a/src/Vde.hs
+++ b/src/Vde.hs
@@ -34,6 +34,6 @@ stop ctx state = do
 
 getVdeCtlDir :: Context -> IO FilePath
 getVdeCtlDir ctx = do
-  let ctlDir = storageDir ctx </> "vde1.ctl"
+  let ctlDir = storageDir ctx </> "vde_switch.ctl"
   createDirectoryIfMissing True ctlDir
   pure ctlDir


### PR DESCRIPTION
I don't think there was a good reason for `vde1.ctl`.